### PR TITLE
Bug fix for very large files.

### DIFF
--- a/simple9.c
+++ b/simple9.c
@@ -113,7 +113,7 @@ static size_t vbyte_decode(size_t *value, FILE *fp)
 
 size_t simple9_encode(uint32_t *array, size_t n, FILE *fp)
 {
-    uint32_t index;
+    size_t index;
     uint32_t selector;
     uint32_t data;
     uint32_t shift;


### PR DESCRIPTION
Bugfix: fixing index type to support compression of very large files.

The type for the variable `index` should be 64-bit wide to support compression of very large texts  (>4GiB).